### PR TITLE
(@W-8946077) Fixing compilation error

### DIFF
--- a/src/main/java/org/jongo/marshall/jackson/configuration/AbstractMappingBuilder.java
+++ b/src/main/java/org/jongo/marshall/jackson/configuration/AbstractMappingBuilder.java
@@ -77,7 +77,7 @@ public abstract class AbstractMappingBuilder<T extends AbstractMappingBuilder<T>
         return getBuilderInstance();
     }
 
-    public T registerModule(final Module module) {
+    public T registerModule(final com.fasterxml.jackson.databind.Module module) {
         modifiers.add(new MapperModifier() {
             public void modify(ObjectMapper mapper) {
                 mapper.registerModule(module);


### PR DESCRIPTION
Addressing this compilation error, with suggestion by @ispringer:
```
[2021-03-24T18:11:04.541Z] [INFO] -------------------< com.evergage.thirdparty:jongo >--------------------
[2021-03-24T18:11:04.542Z] [INFO] Building Jongo 1.5.0-evg4
[2021-03-24T18:11:04.542Z] [INFO] --------------------------------[ jar ]---------------------------------
[2021-03-24T18:11:11.113Z] [INFO] 
[2021-03-24T18:11:11.113Z] [INFO] --- maven-resources-plugin:3.0.2:resources (default-resources) @ jongo ---
[2021-03-24T18:11:11.376Z] [INFO] Using 'UTF-8' encoding to copy filtered resources.
[2021-03-24T18:11:11.377Z] [INFO] skip non existing resourceDirectory /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/src/main/resources
[2021-03-24T18:11:11.378Z] [INFO] 
[2021-03-24T18:11:11.378Z] [INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ jongo ---
[2021-03-24T18:11:12.398Z] [INFO] Changes detected - recompiling the module!
[2021-03-24T18:11:12.399Z] [INFO] Compiling 71 source files to /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/target/classes
[2021-03-24T18:11:13.776Z] [INFO] /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/src/main/java/org/jongo/query/BsonQueryFactory.java: Some input files use or override a deprecated API.
[2021-03-24T18:11:13.776Z] [INFO] /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/src/main/java/org/jongo/query/BsonQueryFactory.java: Recompile with -Xlint:deprecation for details.
[2021-03-24T18:11:13.777Z] [INFO] /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/src/main/java/org/jongo/Command.java: Some input files use unchecked or unsafe operations.
[2021-03-24T18:11:13.778Z] [INFO] /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/src/main/java/org/jongo/Command.java: Recompile with -Xlint:unchecked for details.
[2021-03-24T18:11:13.779Z] [INFO] -------------------------------------------------------------
[2021-03-24T18:11:13.780Z] [ERROR] COMPILATION ERROR : 
[2021-03-24T18:11:13.780Z] [INFO] -------------------------------------------------------------
[2021-03-24T18:11:13.781Z] [ERROR] /var/lib/jenkins/workspace/hypergage_jongo_1.5-hypergage/src/main/java/org/jongo/marshall/jackson/configuration/AbstractMappingBuilder.java:[80,35] reference to Module is ambiguous
[2021-03-24T18:11:13.782Z]   both class com.fasterxml.jackson.databind.Module in com.fasterxml.jackson.databind and class java.lang.Module in java.lang match
[2021-03-24T18:11:13.783Z] [INFO] 1 error
[2021-03-24T18:11:13.783Z] [INFO] -------------------------------------------------------------
```